### PR TITLE
Fixed not running a stir when key length is 0

### DIFF
--- a/hpc.py
+++ b/hpc.py
@@ -120,7 +120,7 @@ def create_kx_table(key, sub_cipher_num, key_len, backup=0):
     cleaned_key = hex_str_to_arr(key)
 
     # Incorporating the content of the key into key expansion table
-    for j in range(math.ceil(len(cleaned_key)/128)):
+    for j in range(max(math.ceil(len(cleaned_key)/128), 1)):
         for i in range(min(len(cleaned_key)-128*j, 128)):
             kx[i] = m_xor(kx[i], cleaned_key[i+j*128])
         _stir(kx, backup)


### PR DESCRIPTION
Fixed not running a stir when key length is 0