### PR TITLE
Fix encryption with blocksize 4

### DIFF
--- a/hpc.py
+++ b/hpc.py
@@ -336,9 +336,9 @@ def tiny_1_6_encrypt(s0, kx, spice, blocksize, cycle_num):
         elif blocksize <= 3:
             for word in tmp:
                 for i in range(math.ceil(32/blocksize)):
-                    s0 = mask_lower(s0 ^ (word & ((1 << blocksize)-1)), blocksize)
-                    word >>= blocksize
                     s0 = mask_lower(s0 + (word & ((1 << blocksize)-1)), blocksize)
+                    word >>= blocksize
+                    s0 = mask_lower(s0 ^ (word & ((1 << blocksize)-1)), blocksize)
                     s0 = m_lrot(s0, 1, blocksize)
                     word >>= blocksize
         else:
@@ -404,9 +404,9 @@ def tiny_1_6_decrypt(s0, kx, spice, blocksize, cycle_num):
                 for i in reversed(range(math.ceil(32/blocksize))):
                     t_word = (word & (m_val << (i * blocksize * 2))) >> (i * blocksize * 2)
                     s0 = _PERM2I_TINY(s0)
-                    s0 -= (t_word >> blocksize)
+                    s0 ^= (t_word >> blocksize)
                     s0 = _PERM1I_TINY(s0)
-                    s0 ^= (t_word & ((1 << blocksize)-1))
+                    s0 -= (t_word & ((1 << blocksize)-1))
     else:
         tmp.append(kx[18+2*blocksize])
         if blocksize == 6:


### PR DESCRIPTION
The spec says:

> For 4 bit numbers, the processing is a little more interesting.  Each word of the tmp array is used to control permutations as in the 2-bit
> and 3-bit cases.  Each temporary variable is used in 4-bit chunks from the low-order end.  8 cycles are necessary to use up each variable.  A cycle adds a 4-bit chunk into s0, then applies PERM1.  Then the next 4-bit chunk is xored into s0, and PERM2 is applied.

That is, add then xor. This implementation had it back to front, perhaps an error derived from 2–3 which *do* use xor then add.